### PR TITLE
Ensure host_address never ends with slash

### DIFF
--- a/gotipy/gotipy.py
+++ b/gotipy/gotipy.py
@@ -59,6 +59,7 @@ class Gotify:
             raise TypeError(
                 'Missing a valid scheme in the host address (e.g., `http://`)!'
             )
+        host_address = host_address.rstrip('/')
         return host_address
 
     def create_app(self, admin_username, admin_password, app_name, desc=None):


### PR DESCRIPTION
Hello!
I had trouble using this library because my host_address ended with a slash (/). I recommend to make sure that the host_address never ends with a slash.
With kind regards